### PR TITLE
Updated - redirect based lang and cat product

### DIFF
--- a/digiwoo_thankyou.php
+++ b/digiwoo_thankyou.php
@@ -38,15 +38,17 @@ if (!class_exists('Digiwoo_ThankYou')) {
         public function custom_redirect($order_id)
         {
             $enabled = get_option('digiwoo_thankyou_enabled');
-            $thank_you_page_en = get_option('digiwoo_thankyou_page_en');
-            $thank_you_page_ja = get_option('digiwoo_thankyou_page_ja');
+            $digiwoo_thankyou_page_challenge_en = get_option('digiwoo_thankyou_page_challenge_en');
+            $digiwoo_thankyou_page_free_trial_en = get_option('digiwoo_thankyou_page_free_trial_en');
+            $digiwoo_thankyou_page_challenge_ja = get_option('digiwoo_thankyou_page_challenge_ja');
+            $digiwoo_thankyou_page_free_trial_ja = get_option('digiwoo_thankyou_page_free_trial_ja');
             $failed_page = get_option('digiwoo_failed_page');
 
             $order = wc_get_order($order_id);
             $order_status = $order->get_status();
 
             // If we're already on the custom thank you page or failed payment page, exit early to avoid redirection loop.
-            if (is_page($thank_you_page_en) || is_page($thank_you_page_ja) || is_page($failed_page)) {
+            if (is_page($digiwoo_thankyou_page_challenge_en) || is_page($digiwoo_thankyou_page_free_trial_en) || is_page($digiwoo_thankyou_page_challenge_ja) || is_page($digiwoo_thankyou_page_free_trial_ja) || is_page($failed_page)) {
                 return;
             }
 
@@ -68,7 +70,7 @@ if (!class_exists('Digiwoo_ThankYou')) {
 
             // Redirect based on language if enabled
             if ($enabled === 'yes') {
-                $redirect_url = $this->get_pll_language_redirect_url($order_id, $order, $thank_you_page_en, $thank_you_page_ja);
+                $redirect_url = $this->get_pll_language_redirect_url($order_id, $order, $digiwoo_thankyou_page_challenge_en, $digiwoo_thankyou_page_free_trial_en, $digiwoo_thankyou_page_challenge_ja, $digiwoo_thankyou_page_free_trial_ja);
                 if ($redirect_url) {
                     wp_safe_redirect($redirect_url);
                     exit;
@@ -76,16 +78,36 @@ if (!class_exists('Digiwoo_ThankYou')) {
             }
         }
 
-        private function get_pll_language_redirect_url($order_id, $order, $thank_you_page_en, $thank_you_page_ja)
+        private function get_pll_language_redirect_url($order_id, $order, $digiwoo_thankyou_page_challenge_en, $digiwoo_thankyou_page_free_trial_en, $digiwoo_thankyou_page_challenge_ja, $digiwoo_thankyou_page_free_trial_ja)
         {
             $language = isset($_COOKIE['pll_language']) ? $_COOKIE['pll_language'] : null;
+            $billing_cat_product = strtolower(str_replace(" ", "", $_POST['billing_cat_product']));
             switch ($language) {
                 case 'en':
-                    return $this->get_redirect_url($thank_you_page_en, $order_id, $order);
+                    if (!empty($billing_cat_product)) {
+                        if ($billing_cat_product === 'challenge') {
+                            return $this->get_redirect_url($digiwoo_thankyou_page_challenge_en, $order_id, $order);
+                        }
+                        if ($billing_cat_product === 'free-trial') {
+                            return $this->get_redirect_url($digiwoo_thankyou_page_free_trial_en, $order_id, $order);
+                        }
+                    }
                 case 'ja':
-                    return $this->get_redirect_url($thank_you_page_ja, $order_id, $order);
+                    if (!empty($billing_cat_product)) {
+                        if ($billing_cat_product === 'challenge') {
+                            return $this->get_redirect_url($digiwoo_thankyou_page_challenge_ja, $order_id, $order);
+                        }
+                        if ($billing_cat_product === 'free-trial') {
+                            return $this->get_redirect_url($digiwoo_thankyou_page_free_trial_ja, $order_id, $order);
+                        }
+                    }
                 default:
-                    return $this->get_redirect_url($thank_you_page_en, $order_id, $order);
+                    if ($billing_cat_product === 'challenge') {
+                        return $this->get_redirect_url($digiwoo_thankyou_page_challenge_en, $order_id, $order);
+                    }
+                    if ($billing_cat_product === 'free-trial') {
+                        return $this->get_redirect_url($digiwoo_thankyou_page_free_trial_en, $order_id, $order);
+                    }
             }
         }
 

--- a/settings.php
+++ b/settings.php
@@ -33,19 +33,33 @@ class WC_Settings_Digiwoo_ThankYou extends WC_Settings_Page
                 'default' => 'no',
                 'id' => 'digiwoo_thankyou_enabled'
             ),
-            'thank_you_page_en' => array(
-                'title' => __('Thank You Page - English', 'digiwoo-thankyou-en'),
+            'thank_you_page_challenge_en' => array(
+                'title' => __('Thank You Page - Challenge - English', 'digiwoo-thankyou-challenge-en'),
                 'type' => 'select',
                 'options' => $this->get_pages(),
                 'default' => '',
-                'id' => 'digiwoo_thankyou_page_en'
+                'id' => 'digiwoo_thankyou_page_challenge_en'
             ),
-            'thank_you_page_ja' => array(
-                'title' => __('Thank You Page - Japanese', 'digiwoo-thankyou-ja'),
+            'thank_you_page_free_trial_en' => array(
+                'title' => __('Thank You Page - Free Trial - English', 'digiwoo-thankyou-free-trial-en'),
                 'type' => 'select',
                 'options' => $this->get_pages(),
                 'default' => '',
-                'id' => 'digiwoo_thankyou_page_ja'
+                'id' => 'digiwoo_thankyou_page_free_trial_en'
+            ),
+            'thank_you_page_challenge_ja' => array(
+                'title' => __('Thank You Page - Challenge - English', 'digiwoo-thankyou-challenge-ja'),
+                'type' => 'select',
+                'options' => $this->get_pages(),
+                'default' => '',
+                'id' => 'digiwoo_thankyou_page_challenge_ja'
+            ),
+            'thank_you_page_free_trial_ja' => array(
+                'title' => __('Thank You Page - Free Trial - English', 'digiwoo-thankyou-free-trial-ja'),
+                'type' => 'select',
+                'options' => $this->get_pages(),
+                'default' => '',
+                'id' => 'digiwoo_thankyou_page_free_trial_ja'
             ),
             'failed_page' => array(
                 'title' => __('Failed Payment Page', 'digiwoo-thankyou'),


### PR DESCRIPTION
Code:
1. Get value cookies lang and value category product 
2. Redirect thank you page base value number one

How to use:
1. Add new custom field category product at Page Checkout > Billings Fields
2. Create new thank you pages for category product (challenge and free-trial)
3. Settup thank you pages at Woocommerce > Settings > YPF Thank You (select page base lang and category)